### PR TITLE
MathConst was renamed Irrational (JuliaLang/julia#11922)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ tau == 2*pi
 using Tau
 
 tau == τ == 2*pi  # => true
-typeof(tau)       # => MathConst{:τ} (constructor with 1 method)
+typeof(tau)       # => Irrational{:τ} (constructor with 1 method)
 ```
 
 The tau variants of `sinpi`, `cospi`, and `mod2pi` are also defined:

--- a/src/Tau.jl
+++ b/src/Tau.jl
@@ -4,7 +4,7 @@ export tau, τ,
        sinτ, cosτ, modτ
 
 # Use overridden macro definition to define conversion methods for tau
-Base.@math_const τ        6.28318530717958647692  (2*big(pi))
+Base.@irrational τ 6.28318530717958647692 (2*big(pi))
 const tau = τ
 
 include("trig.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Base.Test
 @test float32(tau) == 2*float32(pi)
 @test float64(float32(tau)) == float64(2*float32(pi))
 @test big(tau) == 2(big(pi))
-@test isa(tau, MathConst)
+@test isa(tau, Irrational)
 
 # degree-based trig functions
 for T = (Float32,Float64)
@@ -36,4 +36,3 @@ end
 @test_approx_eq modtau(355.0)       3.1416227979431572
 @test_approx_eq modtau(355.0f0)     3.1416228f0
 @test modtau(int64(2)^60) == modtau(2.0 ^ 60)
-


### PR DESCRIPTION
Also some minor whitespace editing:
- in the macro call, the extra whitespace wasn't doing anything useful, contrary to the definitions in base, where it is used for aligment: https://github.com/JuliaLang/julia/blob/f172f4e95d34c50a4885a5238bdc4ebe54224dac/base/irrationals.jl#L103-L107
- at the end of runtests.jl there were two newlines, not just one
