### PR TITLE
test against both 0.4 and 0.5 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
release means 0.5, but according to REQUIRE 0.4 is still supported
so should still be tested